### PR TITLE
Config.yml issues #4

### DIFF
--- a/probe/config.yml
+++ b/probe/config.yml
@@ -8,18 +8,14 @@ probe:
     floor: Semisotano
     room: CPD
   name: probe01
-  sensor:
+  actions:
   - description: You might write here a short description about the particular sensor
     function: null
     id: 1
     module: selenium
-    periodicity: 1h
-    type: Automatism
-    version: 0.1
+    periodicity: 60
   - description: You might write here a short description about the particular sensor
     function: null
     id: 2
     module: dh11
-    periodicity: 15m
-    type: Temperature
-    version: 0.1
+    periodicity: 15


### PR DESCRIPTION
Change the location of Config.yml to the folder probe
Change the tag sensor to the tag actions.
We can assume than we will use only minutes to mesure the periodicity.
For example: 15, 60 or 1440
I should remove the tags called type and version. We can create those
tags when we will need them.